### PR TITLE
Fix paths to model configs

### DIFF
--- a/notebooks/BIIGLE_point_to_polygon_with_sam.ipynb
+++ b/notebooks/BIIGLE_point_to_polygon_with_sam.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +126,7 @@
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
     "\n",
     "# large sam2: works on gpu > 8g\n",
-    "sam2_checkpoint = \"../models/sam2.1_hiera_large.pt\"\n",
+    "sam2_checkpoint = \"../models/sam2_hiera_large.pt\"\n",
     "model_cfg = \"sam2_hiera_l.yaml\"\n",
     "config_dir = \"../models/\"\n",
     "\n",
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/Plot_masks_with_sam-batch.ipynb
+++ b/notebooks/Plot_masks_with_sam-batch.ipynb
@@ -70,9 +70,9 @@
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
     "\n",
     "# large sam2: works on gpu > 8g\n",
-    "sam2_checkpoint = \"../../SAM2_models/checkpoints/sam2_hiera_large.pt\"\n",
+    "sam2_checkpoint = \"../models/sam2_hiera_large.pt\"\n",
     "model_cfg = \"sam2_hiera_l.yaml\"\n",
-    "config_dir = \"../../SAM2_models/configs/\"\n",
+    "config_dir = \"../models/\"\n",
     "\n",
     "# base sam2: smaller version\n",
     "#sam2_checkpoint = \"../../SAM2_models/checkpoints/sam2_hiera_base_plus.pt\"\n",
@@ -209,7 +209,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.15"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/notebooks/automatic_mask_generator.ipynb
+++ b/notebooks/automatic_mask_generator.ipynb
@@ -105,7 +105,7 @@
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
     "\n",
     "# large sam2: works on gpu > 8g\n",
-    "sam2_checkpoint = \"../models/sam2.1_hiera_large.pt\"\n",
+    "sam2_checkpoint = \"../models/sam2_hiera_large.pt\"\n",
     "model_cfg = \"sam2_hiera_l.yaml\"\n",
     "config_dir = \"../models/\"\n",
     "\n",

--- a/notebooks/biigle_sam2_coco.ipynb
+++ b/notebooks/biigle_sam2_coco.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,8 +110,8 @@
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
     "\n",
     "# large sam2: works on gpu > 8g\n",
-    "sam2_checkpoint = \"../models/sam2.1_hiera_large.pt\"\n",
-    "model_cfg = \"configs/sam2.1/sam2.1_hiera_l.yaml\"\n",
+    "sam2_checkpoint = \"../models/sam2_hiera_large.pt\"\n",
+    "model_cfg = str(Path(\"../models/sam2_hiera_l.yaml\").absolute())\n",
     "\n",
     "# base sam2: smaller version\n",
     "# sam2_checkpoint = \"./SAM2_models/sam2.1_hiera_base_plus.pt\"\n",
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -380,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,7 +577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -697,7 +697,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,7 +759,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "oc2p11",
+   "display_name": "sam2",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/paparazzi_point_to_polygon_with_sam.ipynb
+++ b/notebooks/paparazzi_point_to_polygon_with_sam.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
     "\n",
     "# large sam2: works on gpu > 8g\n",
-    "sam2_checkpoint = \"../models/sam2.1_hiera_large.pt\"\n",
+    "sam2_checkpoint = \"../models/sam2_hiera_large.pt\"\n",
     "model_cfg = \"sam2_hiera_l.yaml\"\n",
     "config_dir = \"../models/\"\n",
     "\n",
@@ -219,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.15"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/notebooks/paparazzi_sam2_coco.ipynb
+++ b/notebooks/paparazzi_sam2_coco.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,15 +97,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
     "\n",
     "# large sam2: works on gpu > 8g\n",
-    "sam2_checkpoint = \"../models/sam2.1_hiera_large.pt\"\n",
-    "model_cfg = \"configs/sam2.1/sam2.1_hiera_l.yaml\"\n",
+    "sam2_checkpoint = \"../models/sam2_hiera_large.pt\"\n",
+    "model_cfg = str(Path(\"../models/sam2_hiera_l.yaml\").absolute())\n",
     "\n",
     "# base sam2: smaller version\n",
     "# sam2_checkpoint = \"./SAM2_models/sam2.1_hiera_base_plus.pt\"\n",
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -558,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -677,7 +677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -736,7 +736,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "oc2p11",
+   "display_name": "sam2",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
I changed the filenames to match the one within the `download_model` function. There could be other workarounds to avoid hardcoding the filename.